### PR TITLE
Used strings instead of ints to handle numbers larger than 32 bit

### DIFF
--- a/Test/Model/FibonacciImplTest.php
+++ b/Test/Model/FibonacciImplTest.php
@@ -20,43 +20,47 @@ class FibonacciImplTest extends TestCase {
         return [
             [
                 'input' => 0,
-                'fibonacciNumber' => 0
+                'fibonacciNumber' => '0'
             ],
             [
                 'input' => 1,
-                'fibonacciNumber' => 1
+                'fibonacciNumber' => '1'
             ],
             [
                 'input' => 2,
-                'fibonacciNumber' => 1
+                'fibonacciNumber' => '1'
             ],
             [
                 'input' => 3,
-                'fibonacciNumber' => 2
+                'fibonacciNumber' => '2'
             ],
             [
                 'input' => 4,
-                'fibonacciNumber' => 3
+                'fibonacciNumber' => '3'
             ],
             [
                 'input' => 5,
-                'fibonacciNumber' => 5
+                'fibonacciNumber' => '5'
             ],
             [
                 'input' => 6,
-                'fibonacciNumber' => 8
+                'fibonacciNumber' => '8'
             ],
             [
                 'input' => 20,
-                'fibonacciNumber' => 6765
+                'fibonacciNumber' => '6765'
             ],
+            [
+                'input' => 200,
+                'fibonacciNumber' => '280571172992510140037611932413038677189525'
+            ]
         ];
     }
 
     /**
      * @dataProvider fibonacciCases
      */
-    public function testFirst(int $input, int $fibonacciNumber) {
+    public function testValidCases(int $input, string $fibonacciNumber) {
         $this->assertEquals($fibonacciNumber, $this->fibonacci->getNumber($input));
     }
 

--- a/src/Model/Fibonacci.php
+++ b/src/Model/Fibonacci.php
@@ -5,6 +5,6 @@ namespace Src\Model;
 
 interface Fibonacci {
 
-public function getNumber(int $n): int; // the return type is up to you
+public function getNumber(int $n): string; // the return type is up to you
 
 }

--- a/src/Model/FibonacciImpl.php
+++ b/src/Model/FibonacciImpl.php
@@ -3,14 +3,12 @@
 namespace Src\Model;
 
 class FibonacciImpl implements Fibonacci {
-    public function getNumber(int $n): int {
-        $previous = 0;
-        $current = 1;
+    public function getNumber(int $n): string {
+        $previous = "0";
+        $current = "1";
 
         if ($n < 0) {
             throw new \Exception("Fibonacci Number must be greater than 0");
-        } elseif ($n > 92) {
-            throw new \Exception("Result larger than 32-bits");
         }
 
         switch ($n) {
@@ -19,11 +17,51 @@ class FibonacciImpl implements Fibonacci {
         }
 
         for ($i = 1; $i < $n; $i++) {
-            $next = $previous + $current;
+            $next = $this->stringAddition($previous, $current);
             $previous = $current;
             $current = $next;
         }
 
         return $current;
+    }
+
+    /**
+     * Helper function to add two numbers, represented as strings.
+     * Ex. Input "458" and "3484", return "3942".
+     */
+    private function stringAddition(string $intOne, string $intTwo): string {
+        $larger = $intOne > $intTwo ? $intOne : $intTwo;
+        $smaller = $intOne < $intTwo ? $intOne : $intTwo;
+
+        $largerArrayDigits = array_reverse(str_split($larger));
+        $smallerArrayDigits = array_reverse(str_split($smaller));
+
+        $max_length = strlen($larger);
+        $min_length = strlen($smaller);
+
+        $addition = array();
+
+        $carryover = 0;
+        for ($i=0; $i<$min_length; $i++) {
+            $next_digit = $largerArrayDigits[$i] + $smallerArrayDigits[$i] + $carryover;
+            if ($next_digit >= 10) {
+                $carryover = 1;
+                $next_digit -= 10;
+            } else {
+                $carryover = 0;
+            }
+            $addition[] = $next_digit;
+        }
+
+        if ($min_length === $max_length && $carryover) {
+            $addition[] = $carryover;
+        } else {
+            for ($i = $min_length; $i < $max_length; $i++) {
+                $addition[] = $largerArrayDigits[$i] + $carryover;
+                $carryover = 0;
+            }
+        }
+
+        return join('', array_reverse($addition));
     }
 }

--- a/src/View/FibonacciView.php
+++ b/src/View/FibonacciView.php
@@ -5,12 +5,12 @@ namespace Src\View;
 
 class FibonacciView {
 
-    private ?int $fibonacciNumber;
+    private ?string $fibonacciNumber;
 
     private ?string $errorMessage;
 
     public function __construct(
-        ?int $fibonacciNumber,
+        ?string $fibonacciNumber,
         ?string $errorMessage = null
     ) {
         $this->fibonacciNumber = $fibonacciNumber;


### PR DESCRIPTION
The version of PHP only supports int values up to 32-bit. Decided to use strings to represent the fibonacci numbers instead and created a helper function to add two strings together.